### PR TITLE
Functionality to get full plan list with a maximum of 100 plans per request

### DIFF
--- a/src/Client/BambooClientInterface.php
+++ b/src/Client/BambooClientInterface.php
@@ -30,9 +30,18 @@ interface BambooClientInterface
     public function getLatestResultByKey(string $key): Result;
 
     /**
-     * Get a list of all plans.
+     * Get a list of all plans
      *
      * @return Plan[]
      */
-    public function getPlanList(): array;
+    public function getPlanList();
+
+    /**
+     * Get Bamboo plans paginated with maxResults and startIndex parameters.
+     *
+     * @param int $maxResults
+     * @param int $startIndex
+     * @return array
+     */
+    public function getPlans($startIndex = 0, $maxResults = 25);
 }


### PR DESCRIPTION
Added functionality to get a full list of Bamboo Plans, even when you don't know the exact number of plans. The max request for plans is 100, and the while loop continues until all the plans are fetched.